### PR TITLE
Bug: AiClient

### DIFF
--- a/src/main/java/com/todak/api/infra/ai/AiClient.java
+++ b/src/main/java/com/todak/api/infra/ai/AiClient.java
@@ -22,10 +22,10 @@ public class AiClient {
 
     private final RestTemplate restTemplate;
 
-    @Value("${ai.server.base-url}")
+    @Value("${ai.server.url}")
     private String aiBaseUrl;
 
-    @Value("${ai.server.internal-key}")
+    @Value("${ai.server.key}")
     private String internalKey;
     /**
      * Spring → AI 서버에 Whisper STT 요청

--- a/src/main/java/com/todak/api/infra/ai/AiClient.java
+++ b/src/main/java/com/todak/api/infra/ai/AiClient.java
@@ -36,9 +36,7 @@ public class AiClient {
             MultipartFile file
     ) {
         try {
-            // -----------------------------
             // multipart/form-data 구성
-            // -----------------------------
             MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
             body.add("recordingId", recordingId.toString());
             body.add("consultationId", consultationId.toString());
@@ -55,9 +53,7 @@ public class AiClient {
 
             body.add("file", fileEntity);
 
-            // -----------------------------
             // 최상위 Header
-            // -----------------------------
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.MULTIPART_FORM_DATA);
             headers.set("X-Internal-Key", internalKey);

--- a/src/main/java/com/todak/api/summary/controller/SummaryController.java
+++ b/src/main/java/com/todak/api/summary/controller/SummaryController.java
@@ -35,8 +35,9 @@ public class SummaryController {
     public ResponseEntity<SummaryResponseDto> getSummary(
             @PathVariable Long consultationId
     ) {
-        SummaryResponseDto response = summaryService.getSummaryByConsultation(consultationId);
-      
+        // [수정됨] getSummaryByConsultation -> getLatestByConsultation
+        SummaryResponseDto response = summaryService.getLatestByConsultation(consultationId);
+
         return ResponseEntity.ok(response);
     }
 }


### PR DESCRIPTION
## 📌 개요
`application.yml`의 설정 키 값과 `AiClient` 클래스에서 사용하는 `@Value` 키 값이 달라 발생하는 배포 실패(BeanCreationException) 문제를 수정했습니다.

## 👩‍💻 작업 내용
- **AiClient.java**:
  - `@Value("${ai.server.base-url}")` ➡️ `@Value("${ai.server.url}")` 로 수정
  - `@Value("${ai.server.internal-key}")` ➡️ `@Value("${ai.server.key}")` 로 수정

## 🔗 관련 이슈
- Closes #19 

## 📸 스크린샷 (선택)
- (배포 성공 로그 캡처가 있다면 첨부, 없으면 생략 가능)